### PR TITLE
Fix rollup fs.browser.ts issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "main": "./dist/hive.js",
   "module": "./dist/es/hive.js",
+  "typings": "typings/",
   "browser": {
     "./dist/hive.js": "./dist/hive.browser.js",
     "./dist/es/hive.js": "./dist/es/hive.browser.js"
@@ -27,7 +28,6 @@
     "docs": "npx typedoc src/index.ts --excludePrivate --excludeProtected --excludeInternal",
     "test": "jest"
   },
-  "typings": "typings/",
   "dependencies": {
     "@types/fs-extra": "^9.0.13",
     "axios": "^0.24.0",
@@ -37,7 +37,8 @@
     "jsrsasign-util": "^1.0.2",
     "postcss": "^8.4.4",
     "pretend": "^3.1.0",
-    "tslib": "^2.3.1"
+    "tslib": "^2.3.1",
+    "@elastosfoundation/did-js-sdk": "^2.2.4"
   },
   "repository": {
     "type": "git",
@@ -49,7 +50,6 @@
     "@babel/plugin-proposal-decorators": "^7.16.4",
     "@babel/preset-env": "^7.16.4",
     "@babel/preset-typescript": "^7.13.0",
-    "@elastosfoundation/did-js-sdk": "^2.2.4",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.0.6",
@@ -70,7 +70,6 @@
     "node-fetch": "^2.6.6",
     "path-browserify": "^1.0.1",
     "rollup": "^2.60.1",
-    "rollup-plugin-file-content-replace": "^1.0.0",
     "rollup-plugin-node-globals": "^1.4.0",
     "rollup-plugin-size": "^0.2.2",
     "rollup-plugin-visualizer": "^5.5.2",

--- a/src/service/scripting/scriptingservice.ts
+++ b/src/service/scripting/scriptingservice.ts
@@ -1,7 +1,13 @@
 import { InvalidParameterException, NetworkException, NodeRPCException } from '../../exceptions';
 import { Condition } from './condition';
 import { Executable } from './executable';
-import { ServiceContext, HttpClient, HttpResponseParser, StreamResponseParser, Context, HttpMethod, Logger } from '../..';
+import { ServiceContext } from '../../connection/servicecontext';
+import { HttpClient } from '../../connection/httpclient';
+import { HttpResponseParser } from '../../connection/httpresponseparser';
+import { StreamResponseParser } from '../../connection/streamresponseparser';
+import { Context } from './context';
+import { HttpMethod } from '../../connection/httpmethod';
+import { Logger } from '../../utils/logger';
 import { checkNotNull, checkArgument } from '../../utils/utils';
 import { RestService } from '../restservice';
 


### PR DESCRIPTION
Fixed issue with file-content-replace plugin not finding fs.browser.ts file. The plugin file-content-replace is an old and deprecated tool that was made for an old Node version.

The plugin has been replaced with plugin-replace which is simply replacing the standard fs.ts import from file.ts instead of swapping the whole fs.ts file.

Clickup ticket: https://app.clickup.com/t/2juy8cb